### PR TITLE
security: replace MD5 with SHA-256 for cache filename, fix file permissions

### DIFF
--- a/pkg/gokeenrestapi/common.go
+++ b/pkg/gokeenrestapi/common.go
@@ -55,7 +55,7 @@ func (f *keeneticCacheFile) Save() error {
 	if err != nil {
 		return err
 	}
-	err = os.WriteFile(f.path, b, 0700)
+	err = os.WriteFile(f.path, b, 0600)
 	return err
 }
 
@@ -87,7 +87,7 @@ func (c *keeneticCommon) getKeeneticCacheFile() (keeneticCacheFile, error) {
 		}
 		cleanedOldCacheFiles = true
 	}
-	bHash := md5.Sum(fmt.Appendf(nil, "%v-%v-%v", config.Cfg.Keenetic.URL, config.Cfg.Keenetic.Login, config.Cfg.Keenetic.Password))
+	bHash := sha256.Sum256(fmt.Appendf(nil, "%v-%v", config.Cfg.Keenetic.URL, config.Cfg.Keenetic.Login))
 	hashString := fmt.Sprintf("%x", bHash)
 	keeeticFile := path.Join(gokeenDir, fmt.Sprintf("%v.json", hashString))
 	_, statErr := os.Stat(keeeticFile)
@@ -95,7 +95,7 @@ func (c *keeneticCommon) getKeeneticCacheFile() (keeneticCacheFile, error) {
 		if !errors.Is(statErr, os.ErrNotExist) {
 			return keeneticCacheFile{}, statErr
 		}
-		err = os.WriteFile(keeeticFile, []byte("{}"), os.ModePerm)
+		err = os.WriteFile(keeeticFile, []byte("{}"), 0600)
 		if err != nil {
 			return keeneticCacheFile{}, err
 		}


### PR DESCRIPTION
## Summary

- Replace MD5 with SHA-256 for cache filename derivation
- Remove password from hash input (URL + login is sufficient)
- Fix file permissions: `0700` → `0600` in both `Save()` and initial file creation

Fixes issue NOK-73.