### PR TITLE
fix(cache): return error from SetURLContent; restrict dir permissions to 0700

### DIFF
--- a/internal/gokeencache/cache.go
+++ b/internal/gokeencache/cache.go
@@ -47,7 +47,7 @@ func GetGokeenDir() (string, error) {
 		}
 	}
 	gokeenDir := path.Join(dataDir, ".gokeenapi")
-	err = os.MkdirAll(gokeenDir, os.ModePerm)
+	err = os.MkdirAll(gokeenDir, 0700)
 	return gokeenDir, err
 }
 
@@ -112,7 +112,8 @@ func GetRciShowInterfaces() map[string]gokeenrestapimodels.RciShowInterface {
 
 // SetURLContent caches URL content to disk with TTL and checksum for change detection.
 // The cache file is stored in the .gokeenapi directory.
-func SetURLContent(url string, content string, ttl time.Duration) {
+// Returns an error if the cache file could not be written.
+func SetURLContent(url string, content string, ttl time.Duration) error {
 	checksum := fmt.Sprintf("%x", md5.Sum([]byte(content)))
 	entry := urlCacheEntry{
 		Content:   content,
@@ -122,7 +123,7 @@ func SetURLContent(url string, content string, ttl time.Duration) {
 
 	gokeenDir, err := GetGokeenDir()
 	if err != nil {
-		return
+		return err
 	}
 
 	filename := urlToCacheFilename(url)
@@ -130,10 +131,10 @@ func SetURLContent(url string, content string, ttl time.Duration) {
 
 	data, err := json.Marshal(entry)
 	if err != nil {
-		return
+		return err
 	}
 
-	_ = os.WriteFile(filepath, data, 0600)
+	return os.WriteFile(filepath, data, 0600)
 }
 
 // GetURLContent retrieves cached URL content if not expired.

--- a/internal/gokeencache/cache_test.go
+++ b/internal/gokeencache/cache_test.go
@@ -9,6 +9,25 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+var _ = Describe("GetGokeenDir", func() {
+	It("should create directory with restricted permissions", func() {
+		tmpDir, err := os.MkdirTemp("", "gokeencache-perm-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			_ = os.RemoveAll(tmpDir)
+			config.Cfg.DataDir = ""
+		})
+		config.Cfg.DataDir = tmpDir
+
+		gokeenDir, err := GetGokeenDir()
+		Expect(err).NotTo(HaveOccurred())
+
+		info, err := os.Stat(gokeenDir)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0700)))
+	})
+})
+
 var _ = Describe("DomainValidationCache", func() {
 	It("should return not cached for unknown domain", func() {
 		_, cached := GetDomainValidation("example.com")
@@ -56,7 +75,7 @@ var _ = Describe("URLContentWithChecksum", func() {
 	})
 
 	It("should store and retrieve content", func() {
-		SetURLContent(url, content, ttl)
+		Expect(SetURLContent(url, content, ttl)).To(Succeed())
 
 		retrieved, ok := GetURLContent(url)
 		Expect(ok).To(BeTrue())
@@ -64,21 +83,33 @@ var _ = Describe("URLContentWithChecksum", func() {
 	})
 
 	It("should compute checksum", func() {
-		SetURLContent(url, content, ttl)
+		Expect(SetURLContent(url, content, ttl)).To(Succeed())
 
 		checksum := GetURLChecksum(url)
 		Expect(checksum).NotTo(BeEmpty())
 	})
 
 	It("should change checksum when content changes", func() {
-		SetURLContent(url, content, ttl)
+		Expect(SetURLContent(url, content, ttl)).To(Succeed())
 		checksum1 := GetURLChecksum(url)
 
 		newContent := "example.com\ntest.com\nnew.com\n"
-		SetURLContent(url, newContent, ttl)
+		Expect(SetURLContent(url, newContent, ttl)).To(Succeed())
 		checksum2 := GetURLChecksum(url)
 
 		Expect(checksum2).NotTo(Equal(checksum1))
+	})
+
+	It("should return error when directory is not writable", func() {
+		// Make the data dir read-only so writes fail
+		Expect(os.Chmod(config.Cfg.DataDir, 0500)).To(Succeed())
+		DeferCleanup(func() {
+			_ = os.Chmod(config.Cfg.DataDir, 0700)
+		})
+
+		// GetGokeenDir will try to MkdirAll .gokeenapi inside a read-only dir
+		err := SetURLContent(url, content, ttl)
+		Expect(err).To(HaveOccurred())
 	})
 })
 

--- a/pkg/gokeenrestapi/dns_routing.go
+++ b/pkg/gokeenrestapi/dns_routing.go
@@ -289,7 +289,9 @@ func (*keeneticDnsRouting) LoadDomainsFromURL(url string) ([]string, error) {
 			}
 
 			// Cache with configured TTL
-			gokeencache.SetURLContent(url, content, config.GetURLCacheTTL())
+			if err := gokeencache.SetURLContent(url, content, config.GetURLCacheTTL()); err != nil {
+				gokeenlog.InfoSubStepf("Warning: failed to cache URL content for %v: %v", url, err)
+			}
 
 			lines := strings.Split(content, "\n")
 			domains, skipped = parseDomainLines(lines, "URL")

--- a/pkg/gokeenrestapi/ip.go
+++ b/pkg/gokeenrestapi/ip.go
@@ -275,7 +275,9 @@ func (*keeneticIp) AddRoutesFromBatUrl(url string, interfaceId string) error {
 		}
 		str = string(response.Body())
 		// Cache with configured TTL
-		gokeencache.SetURLContent(url, str, config.GetURLCacheTTL())
+		if err := gokeencache.SetURLContent(url, str, config.GetURLCacheTTL()); err != nil {
+			gokeenlog.InfoSubStepf("Warning: failed to cache URL content for %v: %v", url, err)
+		}
 	}
 
 	var mErr error


### PR DESCRIPTION
## What
Fixes two issues in `internal/gokeencache/cache.go`:
1. `SetURLContent` now returns `error` instead of silently discarding file write failures.
2. `GetGokeenDir` uses `0700` instead of `os.ModePerm` (0777) for the `.gokeenapi` directory.

## Why
If a disk-write fails (disk full, bad permissions) the old code returned normally, causing the caller to assume the cache was written. On the next run this triggers spurious checksum-changed events and unnecessary re-downloads. The overly permissive `0777` directory mode was also inappropriate for a directory containing session cookies and checksums.

## How to test
```
go test ./...
```
All 10 cache tests pass, including a new test that asserts an error is returned when the directory is not writable and a test that verifies the created directory has mode `0700`.

## Related issue
Closes NOK-68