### PR TITLE
fix(docker): run container as non-root user gokeenapi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,11 @@ WORKDIR /opt/gokeenapi
 COPY --from=builder /workspace/gokeenapi ./gokeenapi
 ENV PATH="${PATH}:/opt/gokeenapi"
 ENV GOKEENAPI_INSIDE_DOCKER=true
-RUN mkdir -p /etc/gokeenapi && echo "{}" > /etc/gokeenapi/.gokeenapi
+RUN addgroup -S gokeenapi && adduser -S gokeenapi -G gokeenapi && \
+    mkdir -p /etc/gokeenapi && echo "{}" > /etc/gokeenapi/.gokeenapi && \
+    chown -R gokeenapi:gokeenapi /etc/gokeenapi /opt/gokeenapi
 VOLUME [ "/etc/gokeenapi" ]
+USER gokeenapi
 ENTRYPOINT [ "gokeenapi" ]
 CMD [ "--help" ]
 

--- a/docker_scheduler_integration_test.go
+++ b/docker_scheduler_integration_test.go
@@ -126,7 +126,7 @@ logs:
 			tmpDir = createDockerAccessibleTempDir(GinkgoT())
 
 			batDir := filepath.Join(tmpDir, "batfiles")
-			err := os.MkdirAll(batDir, 0755)
+			err := os.MkdirAll(batDir, 0777)
 			Expect(err).NotTo(HaveOccurred())
 
 			batContent := `route add 1.1.1.0 mask 255.255.255.0 0.0.0.0

--- a/docker_test_helpers.go
+++ b/docker_test_helpers.go
@@ -38,6 +38,11 @@ func createDockerAccessibleTempDir(t cleanupRegistrar) string {
 		return fallbackTempDir(t)
 	}
 
+	// Allow the non-root container user (different UID) to read/write the mounted directory.
+	if err = os.Chmod(tmpDir, 0777); err != nil {
+		return fallbackTempDir(t)
+	}
+
 	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
 	return tmpDir
 }
@@ -45,6 +50,8 @@ func createDockerAccessibleTempDir(t cleanupRegistrar) string {
 func fallbackTempDir(t cleanupRegistrar) string {
 	tmpDir, err := os.MkdirTemp("", "gokeenapi-docker-test-*")
 	Expect(err).NotTo(HaveOccurred())
+	// Allow the non-root container user (different UID) to read/write the mounted directory.
+	Expect(os.Chmod(tmpDir, 0777)).NotTo(HaveOccurred())
 	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
 	return tmpDir
 }


### PR DESCRIPTION
**What**: Add a dedicated non-root system user `gokeenapi` in the final Docker stage and switch to it before the entrypoint.

**Why**: The container was running the `gokeenapi` binary as root (UID 0). If the process is compromised, an attacker would have full root inside the container, violating the principle of least privilege.

**How to test**:
```bash
docker build -t gokeenapi-test .
docker run --rm gokeenapi-test id
# Expected: uid=100(gokeenapi) gid=101(gokeenapi)
```

**Related issue**: Closes NOK-82