### PR TITLE
test: add unit tests for EnsureSaveConfigAtEnd and SaveConfig

### DIFF
--- a/pkg/gokeenrestapi/common.go
+++ b/pkg/gokeenrestapi/common.go
@@ -432,18 +432,19 @@ func (c *keeneticCommon) SaveConfigParseRequest() gokeenrestapimodels.ParseReque
 	return gokeenrestapimodels.ParseRequest{Parse: "system configuration save"}
 }
 
-// EnsureSaveConfigAtEnd ensures SaveConfigParseRequest is at the end of parseSlice if not already present
+// EnsureSaveConfigAtEnd ensures SaveConfigParseRequest is at the end of parseSlice exactly once.
+// Any existing occurrences of the save command are removed before appending it at the end.
 func (c *keeneticCommon) EnsureSaveConfigAtEnd(parseSlice []gokeenrestapimodels.ParseRequest) []gokeenrestapimodels.ParseRequest {
 	saveConfig := c.SaveConfigParseRequest()
 
-	for i, req := range parseSlice {
-		if req.Parse == saveConfig.Parse {
-			parseSlice = append(parseSlice[:i], parseSlice[i+1:]...)
-			break
+	filtered := parseSlice[:0]
+	for _, req := range parseSlice {
+		if req.Parse != saveConfig.Parse {
+			filtered = append(filtered, req)
 		}
 	}
 
-	return append(parseSlice, saveConfig)
+	return append(filtered, saveConfig)
 }
 
 func (c *keeneticCommon) SaveConfig() error {

--- a/pkg/gokeenrestapi/ensure_save_config_test.go
+++ b/pkg/gokeenrestapi/ensure_save_config_test.go
@@ -1,0 +1,86 @@
+package gokeenrestapi
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/noksa/gokeenapi/pkg/gokeenrestapimodels"
+)
+
+var _ = Describe("EnsureSaveConfigAtEnd", func() {
+	saveCmd := "system configuration save"
+
+	makeReqs := func(cmds ...string) []gokeenrestapimodels.ParseRequest {
+		reqs := make([]gokeenrestapimodels.ParseRequest, len(cmds))
+		for i, c := range cmds {
+			reqs[i] = gokeenrestapimodels.ParseRequest{Parse: c}
+		}
+		return reqs
+	}
+
+	It("adds save command to an empty slice", func() {
+		result := Common.EnsureSaveConfigAtEnd(nil)
+		Expect(result).To(HaveLen(1))
+		Expect(result[0].Parse).To(Equal(saveCmd))
+	})
+
+	It("adds save command to the end when absent", func() {
+		input := makeReqs("ip route add", "interface up")
+		result := Common.EnsureSaveConfigAtEnd(input)
+		Expect(result).To(HaveLen(3))
+		Expect(result[2].Parse).To(Equal(saveCmd))
+		Expect(result[0].Parse).To(Equal("ip route add"))
+		Expect(result[1].Parse).To(Equal("interface up"))
+	})
+
+	It("moves save command to end when it is in the middle", func() {
+		input := makeReqs("ip route add", saveCmd, "interface up")
+		result := Common.EnsureSaveConfigAtEnd(input)
+		Expect(result).To(HaveLen(3))
+		Expect(result[2].Parse).To(Equal(saveCmd))
+		Expect(result[0].Parse).To(Equal("ip route add"))
+		Expect(result[1].Parse).To(Equal("interface up"))
+	})
+
+	It("keeps save command at end without duplication when already last", func() {
+		input := makeReqs("ip route add", saveCmd)
+		result := Common.EnsureSaveConfigAtEnd(input)
+		Expect(result).To(HaveLen(2))
+		Expect(result[1].Parse).To(Equal(saveCmd))
+		saveCount := 0
+		for _, r := range result {
+			if r.Parse == saveCmd {
+				saveCount++
+			}
+		}
+		Expect(saveCount).To(Equal(1))
+	})
+
+	It("deduplicates when multiple save commands are present", func() {
+		input := makeReqs(saveCmd, "ip route add", saveCmd)
+		result := Common.EnsureSaveConfigAtEnd(input)
+		Expect(result[len(result)-1].Parse).To(Equal(saveCmd))
+		saveCount := 0
+		for _, r := range result {
+			if r.Parse == saveCmd {
+				saveCount++
+			}
+		}
+		Expect(saveCount).To(Equal(1))
+	})
+})
+
+var _ = Describe("SaveConfig", func() {
+	AfterEach(func() {
+		CleanupTestConfig()
+		restyClient = nil
+	})
+
+	It("executes the save config command against the router", func() {
+		server := SetupMockRouterForTest()
+		DeferCleanup(server.Close)
+
+		err := Common.SaveConfig()
+		Expect(err).NotTo(HaveOccurred())
+	})
+})


### PR DESCRIPTION
## What
Add unit tests for `EnsureSaveConfigAtEnd` and `SaveConfig` in `pkg/gokeenrestapi/ensure_save_config_test.go`.

## Why
Both functions were untested. `EnsureSaveConfigAtEnd` contains non-trivial deduplication logic (called in 11 places) with a latent bug where multiple save commands in the slice would not be fully deduplicated.

## How to test
```
go test ./pkg/gokeenrestapi/...
```
All 6 new specs should pass; full suite should stay green.

## Changes
- **`pkg/gokeenrestapi/ensure_save_config_test.go`** (new): 6 specs covering empty slice, absent save, save in middle, already-last, multiple occurrences, and `SaveConfig` round-trip via mock router.
- **`pkg/gokeenrestapi/common.go`**: fixed `EnsureSaveConfigAtEnd` — replaced loop+break (only removed first duplicate) with filter-then-append (removes all occurrences before appending exactly one).

## Related issue
Closes NOK-84