### PR TITLE
fix: prevent infinite retry loop in authRetryMiddleware on persistent 401

### DIFF
--- a/pkg/gokeenrestapi/common.go
+++ b/pkg/gokeenrestapi/common.go
@@ -1,6 +1,7 @@
 package gokeenrestapi
 
 import (
+	"context"
 	"crypto/md5"
 	"crypto/sha256"
 	"encoding/hex"
@@ -362,9 +363,18 @@ func (c *keeneticCommon) ExecutePostSubPath(path string, body any) ([]byte, erro
 	return []byte{}, errors.New("no response from keenetic api")
 }
 
-// authRetryMiddleware handles 401 responses by re-authenticating and retrying the request
+// authRetried is the context key used to prevent infinite retry loops in authRetryMiddleware.
+type authRetriedKey struct{}
+
+// authRetryMiddleware handles 401 responses by re-authenticating and retrying the request.
+// It uses a context flag to ensure the retry is performed at most once per request.
 func (c *keeneticCommon) authRetryMiddleware(client *resty.Client, resp *resty.Response) error {
 	if resp.StatusCode() == http.StatusUnauthorized && resp.Request.RawRequest.URL.Path != "/auth" {
+		// Prevent infinite loop: if this request is already a retry, do not retry again.
+		if resp.Request.Context().Value(authRetriedKey{}) != nil {
+			return nil
+		}
+
 		// Clear the current cookie and perform direct authentication
 		client.Header.Del("Cookie")
 
@@ -372,9 +382,8 @@ func (c *keeneticCommon) authRetryMiddleware(client *resty.Client, resp *resty.R
 			return err
 		}
 
-		// Retry the original request with new authentication
-
-		retryReq := resp.Request
+		// Retry the original request with new authentication, marking it as already retried.
+		retryReq := resp.Request.SetContext(context.WithValue(resp.Request.Context(), authRetriedKey{}, true))
 		retryReq.Header.Del("Cookie")
 		retryReq.Header.Set("Cookie", client.Header.Get("Cookie"))
 


### PR DESCRIPTION
## Summary

Fixes an infinite retry loop in `authRetryMiddleware` when a retried request returns 401 again.

## Problem

`authRetryMiddleware` intercepts 401 responses, re-authenticates, and retries the original request. However, it had no guard against the retry itself returning 401 — if the retried request still returned 401 (e.g., wrong endpoint permissions), the middleware would be invoked again on the retried response, creating an infinite loop.

The resty client's `RetryCount=3` only limits network-error retries; `OnAfterResponse` callbacks are not bounded by it.

## Fix

Added a private context key type `authRetriedKey` used as a sentinel. Before retrying, the middleware sets this key on the request context via `context.WithValue`. At the top of the middleware, we check for the key and return early if already set — capping auth retries to exactly one per request.

**Files changed:** `pkg/gokeenrestapi/common.go`

## Testing

All existing tests pass.