### PR TITLE
fix(api): protect restyClient and cleanedOldCacheFiles with sync primitives

### DIFF
--- a/pkg/gokeenrestapi/common.go
+++ b/pkg/gokeenrestapi/common.go
@@ -14,6 +14,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fatih/color"
@@ -33,8 +34,12 @@ const (
 )
 
 var (
-	restyClient          *resty.Client
-	cleanedOldCacheFiles bool
+	restyClient     *resty.Client
+	restyClientOnce sync.Once
+
+	cacheCleanMu    sync.Mutex
+	cleanedOldCache bool
+
 	// Common provides core API functionality for authentication and router communication
 	Common keeneticCommon
 )
@@ -66,7 +71,13 @@ func (c *keeneticCommon) getKeeneticCacheFile() (keeneticCacheFile, error) {
 		return keeneticCacheFile{}, err
 	}
 
-	if !cleanedOldCacheFiles {
+	cacheCleanMu.Lock()
+	needClean := !cleanedOldCache
+	if needClean {
+		cleanedOldCache = true
+	}
+	cacheCleanMu.Unlock()
+	if needClean {
 		err = filepath.WalkDir(gokeenDir, func(path string, d fs.DirEntry, err error) error {
 			if d.IsDir() {
 				return nil
@@ -84,9 +95,11 @@ func (c *keeneticCommon) getKeeneticCacheFile() (keeneticCacheFile, error) {
 			return nil
 		})
 		if err != nil {
+			cacheCleanMu.Lock()
+			cleanedOldCache = false // allow retry on next call
+			cacheCleanMu.Unlock()
 			return keeneticCacheFile{}, err
 		}
-		cleanedOldCacheFiles = true
 	}
 	bHash := sha256.Sum256(fmt.Appendf(nil, "%v-%v", config.Cfg.Keenetic.URL, config.Cfg.Keenetic.Login))
 	hashString := fmt.Sprintf("%x", bHash)
@@ -400,14 +413,14 @@ func (c *keeneticCommon) authRetryMiddleware(client *resty.Client, resp *resty.R
 
 // GetApiClient returns a configured HTTP client for API requests with authentication
 func (c *keeneticCommon) GetApiClient() (*resty.Client, error) {
-	if restyClient == nil {
+	restyClientOnce.Do(func() {
 		restyClient = resty.New()
 		restyClient.SetDisableWarn(true)
 		restyClient.SetCookieJar(nil)
 		restyClient.SetTimeout(defaultTimeout)
 		restyClient.OnAfterResponse(c.authRetryMiddleware)
 		restyClient.RetryCount = 3
-	}
+	})
 	// do it each time to have clean client
 	restyClient.SetBaseURL(config.Cfg.Keenetic.URL)
 	if restyClient.Header.Get("Cookie") == "" {

--- a/pkg/gokeenrestapi/common_test.go
+++ b/pkg/gokeenrestapi/common_test.go
@@ -2,6 +2,7 @@ package gokeenrestapi
 
 import (
 	"os"
+	"sync"
 
 	"github.com/noksa/gokeenapi/pkg/config"
 	. "github.com/onsi/ginkgo/v2"
@@ -50,7 +51,8 @@ var _ = Describe("GetApiClient", func() {
 	AfterEach(func() {
 		CleanupTestConfig()
 		restyClient = nil
-		cleanedOldCacheFiles = false
+		restyClientOnce = sync.Once{}
+		cleanedOldCache = false
 	})
 
 	It("should return error instead of panicking when auth cache directory is unreadable", func() {
@@ -68,7 +70,8 @@ var _ = Describe("GetApiClient", func() {
 			DataDir:  tmpDir,
 		}
 		restyClient = nil
-		cleanedOldCacheFiles = false
+		restyClientOnce = sync.Once{}
+		cleanedOldCache = false
 
 		client, getErr := Common.GetApiClient()
 		Expect(getErr).To(HaveOccurred())

--- a/pkg/gokeenrestapi/ensure_save_config_test.go
+++ b/pkg/gokeenrestapi/ensure_save_config_test.go
@@ -1,6 +1,8 @@
 package gokeenrestapi
 
 import (
+	"sync"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -74,6 +76,7 @@ var _ = Describe("SaveConfig", func() {
 	AfterEach(func() {
 		CleanupTestConfig()
 		restyClient = nil
+		restyClientOnce = sync.Once{}
 	})
 
 	It("executes the save config command against the router", func() {

--- a/pkg/gokeenrestapi/test_helpers.go
+++ b/pkg/gokeenrestapi/test_helpers.go
@@ -2,6 +2,7 @@ package gokeenrestapi
 
 import (
 	"os"
+	"sync"
 
 	"github.com/noksa/gokeenapi/pkg/config"
 )
@@ -26,8 +27,9 @@ func SetupTestConfig(serverURL string) {
 		},
 		DataDir: tmpDir,
 	}
-	// Reset client to use new config
+	// Reset client and its Once guard so the next call re-initializes with the new config.
 	restyClient = nil
+	restyClientOnce = sync.Once{}
 }
 
 // CleanupTestConfig removes the temporary test cache directory


### PR DESCRIPTION
## What
Protect two package-level mutable globals in `pkg/gokeenrestapi/common.go` against concurrent access with the appropriate sync primitives.

## Why
When the scheduler runs with the `parallel` strategy, multiple goroutines fan out and call `GetApiClient` and `getKeeneticCacheFile` simultaneously. Both functions accessed shared globals (`restyClient`, `cleanedOldCacheFiles`) without synchronization, creating data races that could cause nil-pointer dereferences or double-execution of the cache cleanup walk.

## Changes
- **`restyClient`** — replaced bare nil-check with `sync.Once` for thread-safe lazy initialization.
- **`cleanedOldCacheFiles`** — protected with `sync.Mutex`; flag is set before the walk begins so concurrent goroutines skip it; reset on walk error so cleanup is retried next call.
- **Test helpers** — `SetupTestConfig` and `AfterEach` blocks reset `restyClientOnce = sync.Once{}` alongside `restyClient = nil` to maintain per-test isolation.

## How to test
```
go test -race ./...
```

All tests pass with the race detector enabled.

## Related issue
NOK-60 — Race condition on global restyClient and cleanedOldCacheFiles in concurrent scheduler use