### PR TITLE
fix(scheduler): use select on queue send to respect context cancellation

### DIFF
--- a/cmd/scheduler.go
+++ b/cmd/scheduler.go
@@ -183,6 +183,17 @@ func runTask(ctx context.Context, task config.ScheduledTask, queue chan<- config
 	}
 }
 
+// sendTask sends a task to the queue, respecting context cancellation.
+// Returns false if the context was cancelled before the send completed.
+func sendTask(ctx context.Context, task config.ScheduledTask, queue chan<- config.ScheduledTask) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case queue <- task:
+		return true
+	}
+}
+
 // runIntervalTask runs task at specified intervals
 func runIntervalTask(ctx context.Context, task config.ScheduledTask, queue chan<- config.ScheduledTask) {
 	interval, _ := time.ParseDuration(task.Interval)
@@ -191,14 +202,18 @@ func runIntervalTask(ctx context.Context, task config.ScheduledTask, queue chan<
 
 	gokeenlog.InfoSubStepf("Task '%v': running every %s", color.CyanString(task.Name), color.BlueString("%v", interval))
 
-	queue <- task
+	if !sendTask(ctx, task, queue) {
+		return
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			queue <- task
+			if !sendTask(ctx, task, queue) {
+				return
+			}
 		}
 	}
 }
@@ -215,7 +230,9 @@ func runTimedTask(ctx context.Context, task config.ScheduledTask, queue chan<- c
 		case <-ctx.Done():
 			return
 		case <-time.After(waitDuration):
-			queue <- task
+			if !sendTask(ctx, task, queue) {
+				return
+			}
 		}
 	}
 }

--- a/cmd/scheduler_test.go
+++ b/cmd/scheduler_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -306,6 +307,75 @@ var _ = Describe("Scheduler", func() {
 			cfg, err := config.LoadSchedulerConfig(configPath)
 			Expect(err).To(HaveOccurred())
 			Expect(cfg.Tasks).To(BeEmpty())
+		})
+	})
+
+	Describe("sendTask", func() {
+		It("should send task to queue when space available", func() {
+			ctx := context.Background()
+			queue := make(chan config.ScheduledTask, 1)
+			task := config.ScheduledTask{Name: "t1"}
+
+			ok := sendTask(ctx, task, queue)
+
+			Expect(ok).To(BeTrue())
+			Expect(queue).To(HaveLen(1))
+			Expect(<-queue).To(Equal(task))
+		})
+
+		It("should return false immediately when context is already cancelled", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+			// unbuffered: send would block forever without ctx cancellation
+			queue := make(chan config.ScheduledTask)
+			task := config.ScheduledTask{Name: "t1"}
+
+			ok := sendTask(ctx, task, queue)
+
+			Expect(ok).To(BeFalse())
+			Expect(queue).To(HaveLen(0))
+		})
+
+		It("should return false when context is cancelled while queue is full", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			queue := make(chan config.ScheduledTask) // unbuffered, always blocks
+
+			done := make(chan bool, 1)
+			go func() {
+				done <- sendTask(ctx, config.ScheduledTask{Name: "t1"}, queue)
+			}()
+
+			// cancel while sendTask is blocked waiting for a receiver
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+
+			Eventually(done, "1s").Should(Receive(BeFalse()))
+		})
+	})
+
+	Describe("runIntervalTask cancellation", func() {
+		It("should exit promptly on context cancellation even when queue is full", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			// queue size 1: first immediate send fills it; subsequent tick sends block
+			queue := make(chan config.ScheduledTask, 1)
+			task := config.ScheduledTask{
+				Name:     "interval-task",
+				Commands: []string{"add-routes"},
+				Configs:  []string{"/cfg.yaml"},
+				Interval: "10ms",
+			}
+
+			done := make(chan struct{})
+			go func() {
+				runIntervalTask(ctx, task, queue)
+				close(done)
+			}()
+
+			// let the goroutine start and the first send land
+			time.Sleep(20 * time.Millisecond)
+			cancel()
+
+			Eventually(done, "500ms").Should(BeClosed())
 		})
 	})
 })


### PR DESCRIPTION
## What

Replace bare `queue <- task` channel sends in `runIntervalTask` and `runTimedTask` with a `sendTask` helper that selects on both the queue channel and `ctx.Done()`.

## Why

When the 100-slot queue is full, a bare `queue <- task` blocks indefinitely. The producer goroutine is stuck on that send and cannot reach the `ctx.Done()` arm of its own select loop. This means a graceful-shutdown signal (Ctrl+C) is ignored and the process hangs until forcibly killed.

By routing all sends through `sendTask`, producers exit cleanly as soon as the context is cancelled regardless of queue state.

## How to test

1. Create a scheduler config with many tasks at short intervals (e.g. 100 tasks × `interval: 1s`).
2. Run `gokeenapi scheduler --config scheduler.yaml`.
3. Press Ctrl+C — the process should exit within ~100 ms instead of hanging.

Unit tests added:

- `sendTask`: sends to a buffered queue; returns `false` immediately on a pre-cancelled context; unblocks via context cancel while blocked on an unbuffered channel.
- `runIntervalTask`: exits promptly when the context is cancelled with the queue already full.

## Related issue

Closes NOK-76
