### PR TITLE
docs: add missing command aliases to README and README_RU

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Here are some of the things you can do with `gokeenapi`. For a full list of comm
 
 #### `show-interfaces`
 
-*Aliases: `showinterfaces`, `showifaces`, `si`*
+*Aliases: `showinterfaces`, `si`, `showinterface`, `show-interface`*
 
 Displays all available interfaces on your Keenetic (Netcraze) router.
 
@@ -321,7 +321,7 @@ Deletes static DNS records based on your configuration file.
 
 #### `add-dns-routing`
 
-*Aliases: `adddnsrouting`, `adnsr`*
+*Aliases: `adddnsrouting`, `adnsr`, `adddnsroutes`, `add-dns-routes`*
 
 Adds DNS-routing rules (policy-based routing by domain) to your router. This feature allows you to route traffic for specific domains through designated network interfaces.
 
@@ -387,7 +387,7 @@ This allows you to maintain common DNS routing rules in one place and share them
 
 #### `delete-dns-routing`
 
-*Aliases: `deletednsrouting`, `ddnsr`*
+*Aliases: `deletednsrouting`, `ddnsr`, `deletednsroutes`, `delete-dns-routes`*
 
 Deletes DNS-routing rules that match your configuration file.
 
@@ -440,6 +440,16 @@ Deletes known hosts by name or MAC using regex pattern.
 
 # Delete hosts without confirmation prompt
 ./gokeenapi delete-known-hosts --config my_config.yaml --name-pattern "pattern" --force
+```
+
+#### `scheduler`
+
+*Aliases: `schedule`, `sched`*
+
+Runs automated tasks at specified intervals or fixed times. See [Scheduler documentation](SCHEDULER.md) for the full configuration reference.
+
+```shell
+./gokeenapi scheduler --config scheduler.yaml
 ```
 
 #### `exec`

--- a/README_RU.md
+++ b/README_RU.md
@@ -252,7 +252,7 @@ tasks:
 
 #### `show-interfaces`
 
-*Псевдонимы: `showinterfaces`, `showifaces`, `si`*
+*Псевдонимы: `showinterfaces`, `si`, `showinterface`, `show-interface`*
 
 Отображает все доступные интерфейсы на вашем роутере Keenetic (Netcraze).
 
@@ -313,7 +313,7 @@ tasks:
 
 #### `add-dns-routing`
 
-*Псевдонимы: `adddnsrouting`, `adnsr`*
+*Псевдонимы: `adddnsrouting`, `adnsr`, `adddnsroutes`, `add-dns-routes`*
 
 Добавляет правила DNS-маршрутизации (маршрутизация по доменам) в ваш роутер. Эта функция позволяет направлять трафик для определенных доменов через указанные сетевые интерфейсы.
 
@@ -379,7 +379,7 @@ dns:
 
 #### `delete-dns-routing`
 
-*Псевдонимы: `deletednsrouting`, `ddnsr`*
+*Псевдонимы: `deletednsrouting`, `ddnsr`, `deletednsroutes`, `delete-dns-routes`*
 
 Удаляет правила DNS-маршрутизации, соответствующие вашему конфигурационному файлу.
 
@@ -432,6 +432,16 @@ dns:
 
 # Удалить хосты без подтверждения
 ./gokeenapi delete-known-hosts --config my_config.yaml --name-pattern "паттерн" --force
+```
+
+#### `scheduler`
+
+*Псевдонимы: `schedule`, `sched`*
+
+Запускает автоматизированные задачи по расписанию или через заданные интервалы. Полную документацию см. в [документации Scheduler](SCHEDULER_RU.md).
+
+```shell
+./gokeenapi scheduler --config scheduler.yaml
 ```
 
 #### `exec`


### PR DESCRIPTION
## Summary

Several command aliases defined in `cmd/constants.go` were missing from the README documentation.

### Changes

- `show-interfaces`: added `showinterface`, `show-interface`
- `add-dns-routing`: added `adddnsroutes`, `add-dns-routes`
- `delete-dns-routing`: added `deletednsroutes`, `delete-dns-routes`
- `scheduler`: added entry to Commands section with aliases `schedule`, `sched` (was entirely absent)

Applied to both README.md and README_RU.md.