### PR TITLE
Maintenance: fix(main): store and defer cancel from signal.NotifyContext

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,8 @@ import (
 func main() {
 	rootCmd := cmd.NewRootCmd()
 	ctx := context.Background()
-	cmdCtx, _ := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	cmdCtx, cancel := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
+	defer cancel()
 	var err error
 	errChan := make(chan error)
 	go func() {


### PR DESCRIPTION
**What**: Store and defer the cancel function returned by `signal.NotifyContext` instead of discarding it.

**Why**: Discarding the cancel leaks the signal channel goroutine registered inside `signal.NotifyContext` for the lifetime of the process. This also silences the `govet` warning about the unused return value.

**How to test**: `go vet ./...` and `go build ./...` both pass clean.