### PR TITLE
Maintenance: fix(cache): ignore ErrNotExist in cache cleanup WalkDir

### DIFF
--- a/pkg/gokeenrestapi/common.go
+++ b/pkg/gokeenrestapi/common.go
@@ -79,17 +79,25 @@ func (c *keeneticCommon) getKeeneticCacheFile() (keeneticCacheFile, error) {
 	cacheCleanMu.Unlock()
 	if needClean {
 		err = filepath.WalkDir(gokeenDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					return nil
+				}
+				return err
+			}
 			if d.IsDir() {
 				return nil
 			}
 			info, err := d.Info()
 			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					return nil
+				}
 				return err
 			}
 			if time.Since(info.ModTime()) >= cacheCleanupPeriod {
-				err = os.Remove(path)
-				if err != nil {
-					return err
+				if removeErr := os.Remove(path); removeErr != nil && !errors.Is(removeErr, os.ErrNotExist) {
+					return removeErr
 				}
 			}
 			return nil

--- a/pkg/gokeenrestapi/common_test.go
+++ b/pkg/gokeenrestapi/common_test.go
@@ -3,6 +3,7 @@ package gokeenrestapi
 import (
 	"os"
 	"sync"
+	"time"
 
 	"github.com/noksa/gokeenapi/pkg/config"
 	. "github.com/onsi/ginkgo/v2"
@@ -76,5 +77,75 @@ var _ = Describe("GetApiClient", func() {
 		client, getErr := Common.GetApiClient()
 		Expect(getErr).To(HaveOccurred())
 		Expect(client).To(BeNil())
+	})
+})
+
+var _ = Describe("cache cleanup", func() {
+	var tmpDir string
+	var gokeenDir string
+
+	BeforeEach(func() {
+		var err error
+		tmpDir, err = os.MkdirTemp("", "gokeenapi-cache-test-*")
+		Expect(err).NotTo(HaveOccurred())
+		config.Cfg = config.GokeenapiConfig{
+			Keenetic: config.Keenetic{URL: "http://127.0.0.1:9999", Login: "admin", Password: "pass"},
+			DataDir:  tmpDir,
+		}
+		// GetGokeenDir creates tmpDir/.gokeenapi
+		gokeenDir = tmpDir + "/.gokeenapi"
+		Expect(os.MkdirAll(gokeenDir, 0700)).To(Succeed())
+		restyClient = nil
+		restyClientOnce = sync.Once{}
+		cleanedOldCache = false
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(tmpDir)
+		cleanedOldCache = false
+	})
+
+	It("should not error when a stale file is already deleted by a concurrent process", func() {
+		// Create a stale file (modified > cacheCleanupPeriod ago)
+		staleFile, err := os.CreateTemp(gokeenDir, "stale-*.json")
+		Expect(err).NotTo(HaveOccurred())
+		stalePath := staleFile.Name()
+		Expect(staleFile.Close()).To(Succeed())
+
+		// Back-date modification time past the cleanup period
+		oldTime := time.Now().Add(-(cacheCleanupPeriod + time.Hour))
+		Expect(os.Chtimes(stalePath, oldTime, oldTime)).To(Succeed())
+
+		// Simulate concurrent deletion before our WalkDir removes it
+		Expect(os.Remove(stalePath)).To(Succeed())
+
+		// getKeeneticCacheFile should succeed even though the file is already gone
+		_, err = Common.getKeeneticCacheFile()
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should remove stale files that still exist", func() {
+		staleFile, err := os.CreateTemp(gokeenDir, "stale-*.json")
+		Expect(err).NotTo(HaveOccurred())
+		stalePath := staleFile.Name()
+		Expect(staleFile.Close()).To(Succeed())
+
+		oldTime := time.Now().Add(-(cacheCleanupPeriod + time.Hour))
+		Expect(os.Chtimes(stalePath, oldTime, oldTime)).To(Succeed())
+
+		_, err = Common.getKeeneticCacheFile()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(stalePath).NotTo(BeAnExistingFile())
+	})
+
+	It("should not remove fresh files", func() {
+		freshFile, err := os.CreateTemp(gokeenDir, "fresh-*.json")
+		Expect(err).NotTo(HaveOccurred())
+		freshPath := freshFile.Name()
+		Expect(freshFile.Close()).To(Succeed())
+
+		_, err = Common.getKeeneticCacheFile()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(freshPath).To(BeAnExistingFile())
 	})
 })


### PR DESCRIPTION
**What**: Handle `os.ErrNotExist` in all three error paths inside the `WalkDir` callback of `getKeeneticCacheFile`.

**Why**: When two gokeenapi instances run simultaneously (e.g. a scheduler spawning subprocesses), both may walk the cache directory and race to delete the same stale files. The callback never checked the incoming `err` argument and returned `os.Remove` errors verbatim, so a concurrent deletion would surface as a hard error and abort the caller.

**How to test**:
1. `go test ./pkg/gokeenrestapi/... -run 'cache cleanup'` — three new specs cover the race (already-deleted file), normal removal of stale files, and preservation of fresh files.
2. `go test ./pkg/... ./cmd/... ./internal/...` — full suite passes.

**Related issue**: NOK-160