### PR TITLE
Maintenance: fix(ip): check HTTP status code in AddRoutesFromBatUrl

### DIFF
--- a/pkg/gokeenrestapi/ip.go
+++ b/pkg/gokeenrestapi/ip.go
@@ -268,7 +268,13 @@ func (*keeneticIp) AddRoutesFromBatUrl(url string, interfaceId string) error {
 		var response *resty.Response
 		err = gokeenspinner.WrapWithSpinner(fmt.Sprintf("Fetching %v url", color.CyanString(url)), func() error {
 			response, err = rClient.R().Get(url)
-			return err
+			if err != nil {
+				return err
+			}
+			if response.StatusCode() != 200 {
+				return fmt.Errorf("unexpected status code %d", response.StatusCode())
+			}
+			return nil
 		})
 		if err != nil {
 			return err

--- a/pkg/gokeenrestapi/ip_test.go
+++ b/pkg/gokeenrestapi/ip_test.go
@@ -1,6 +1,7 @@
 package gokeenrestapi
 
 import (
+	"net/http"
 	"net/http/httptest"
 
 	"github.com/noksa/gokeenapi/pkg/gokeenrestapimodels"
@@ -62,5 +63,19 @@ var _ = Describe("Ip", func() {
 
 	It("should delete DNS records", func() {
 		Expect(Ip.DeleteDnsRecords([]string{"example.com", "test.local"})).To(Succeed())
+	})
+
+	Describe("AddRoutesFromBatUrl", func() {
+		It("should return an error on non-200 response", func() {
+			for _, statusCode := range []int{http.StatusNotFound, http.StatusInternalServerError, http.StatusForbidden} {
+				batServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.WriteHeader(statusCode)
+				}))
+				err := Ip.AddRoutesFromBatUrl(batServer.URL, "Wireguard0")
+				batServer.Close()
+				Expect(err).To(HaveOccurred(), "expected error for status %d", statusCode)
+				Expect(err.Error()).To(ContainSubstring("unexpected status code"))
+			}
+		})
 	})
 })


### PR DESCRIPTION
**What**: Add HTTP response status code check after fetching the URL in `AddRoutesFromBatUrl`, returning an error on non-2xx responses.

**Why**: Without the check, a 404 or 500 response body was silently passed to the route parser, potentially producing garbage route data. The companion function `LoadDomainsFromURL` in `dns_routing.go` already performs this check correctly.

**How to test**: Run `go test ./pkg/gokeenrestapi/...` — the new spec `Ip > AddRoutesFromBatUrl > should return an error on non-200 response` verifies that status codes 404, 500, and 403 all cause an error containing "unexpected status code".

**Related issue**: NOK-162