### PR TITLE
Maintenance: fix(restapi): skip batch on unmarshal error in ExecutePostParse

### DIFF
--- a/pkg/gokeenrestapi/common.go
+++ b/pkg/gokeenrestapi/common.go
@@ -326,7 +326,10 @@ func (c *keeneticCommon) ExecutePostParse(parse ...gokeenrestapimodels.ParseRequ
 			}
 			var parseResponse []gokeenrestapimodels.ParseResponse
 			decodeErr := json.Unmarshal(response.Body(), &parseResponse)
-			mErr = multierr.Append(mErr, decodeErr)
+			if decodeErr != nil {
+				mErr = multierr.Append(mErr, decodeErr)
+				continue
+			}
 			for i, myParse := range parseResponse {
 				if i == 0 {
 					parseResponse[i].Parse.DynamicData = string(response.Body())

--- a/pkg/gokeenrestapi/common_test.go
+++ b/pkg/gokeenrestapi/common_test.go
@@ -5,9 +5,29 @@ import (
 	"sync"
 
 	"github.com/noksa/gokeenapi/pkg/config"
+	"github.com/noksa/gokeenapi/pkg/gokeenrestapimodels"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
+
+var _ = Describe("ExecutePostParse", func() {
+	AfterEach(func() {
+		CleanupTestConfig()
+	})
+
+	It("should skip batch and return error when response body is not valid JSON", func() {
+		server := SetupMockRouterForTest(WithRciBody([]byte("not valid json")))
+		DeferCleanup(server.Close)
+
+		responses, err := Common.ExecutePostParse(
+			gokeenrestapimodels.ParseRequest{Parse: "interface Wireguard0 up"},
+		)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("invalid"))
+		// No partial results should leak through on unmarshal failure
+		Expect(responses).To(BeEmpty())
+	})
+})
 
 var _ = Describe("CheckRouterMode", func() {
 	AfterEach(func() {

--- a/pkg/gokeenrestapi/mock_router.go
+++ b/pkg/gokeenrestapi/mock_router.go
@@ -140,6 +140,7 @@ type MockRouter struct {
 	initialState        MockRouterState // Store initial state for reset functionality
 	staticRunningConfig []string        // Optional static running config (overrides generated config)
 	version             string          // Router firmware version (default: "4.3.6.3")
+	rciBodyOverride     []byte          // Optional fixed response body for /rci/ endpoint
 }
 
 // MockRouterOption is a functional option for configuring the mock router
@@ -220,6 +221,14 @@ func WithDnsRoutingGroups(groups []MockDnsRoutingGroup, routes []MockDnsProxyRou
 func WithVersion(version string) MockRouterOption {
 	return func(m *MockRouter) {
 		m.version = version
+	}
+}
+
+// WithRciBody overrides the /rci/ POST endpoint to return a fixed raw body.
+// Useful for testing how callers handle malformed or unexpected responses.
+func WithRciBody(body []byte) MockRouterOption {
+	return func(m *MockRouter) {
+		m.rciBodyOverride = body
 	}
 }
 
@@ -895,6 +904,15 @@ func (m *MockRouter) handleHotspot(w http.ResponseWriter, r *http.Request) {
 func (m *MockRouter) handleParse(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	m.mu.RLock()
+	override := m.rciBodyOverride
+	m.mu.RUnlock()
+	if override != nil {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(override)
 		return
 	}
 


### PR DESCRIPTION
**What**: On `json.Unmarshal` failure in `ExecutePostParse`, skip the current batch instead of continuing to process a nil `parseResponse` slice, which was mixing nil/zero results with the accumulated error.

**Why**: The previous code appended the unmarshal error to `mErr` but then fell through to the loop over the (nil) `parseResponse`, appending nothing to `parseResponses` but still making the caller unable to distinguish which results were valid. Adding `continue` makes the behaviour explicit: a failed batch contributes an error and zero results.

**How to test**:
1. `go test ./pkg/gokeenrestapi/... -v` — all 122 specs pass, including the new `ExecutePostParse` spec that injects invalid JSON via `WithRciBody` and asserts the error is surfaced and no responses are returned.