### PR TITLE
Maintenance: fix race condition on shared restyClient singleton

### DIFF
--- a/pkg/gokeenrestapi/common.go
+++ b/pkg/gokeenrestapi/common.go
@@ -37,6 +37,14 @@ const (
 var (
 	restyClient     *resty.Client
 	restyClientOnce sync.Once
+	restyClientMu   sync.Mutex // serialises concurrent re-authentication
+
+	// cachedCookie mirrors the on-disk auth cookie in memory so that concurrent
+	// requests can read it without hitting the filesystem on every call.
+	// cachedCookieMu also serialises the first-time cache-file initialisation to
+	// prevent concurrent goroutines from racing on file creation.
+	cachedCookieMu sync.Mutex
+	cachedCookie   string
 
 	cacheCleanMu    sync.Mutex
 	cleanedOldCache bool
@@ -134,9 +142,22 @@ func (c *keeneticCommon) getKeeneticCacheFile() (keeneticCacheFile, error) {
 }
 
 func (c *keeneticCommon) getAuthCookie() (string, error) {
+	// Serialize all cookie reads/writes so concurrent first-time initialisation
+	// does not race on cache-file creation.
+	cachedCookieMu.Lock()
+	defer cachedCookieMu.Unlock()
+
+	if cachedCookie != "" {
+		return cachedCookie, nil
+	}
+
 	cache, err := c.getKeeneticCacheFile()
 	if err != nil {
 		return "", err
+	}
+
+	if cookie := cache.Cookie.Value; cookie != "" {
+		cachedCookie = cookie
 	}
 	return cache.Cookie.Value, nil
 }
@@ -148,7 +169,13 @@ func (c *keeneticCommon) writeAuthCookie(cookie string) error {
 	}
 	cache.Cookie.Value = cookie
 	cache.Cookie.UpdateTime = time.Now()
-	return cache.Save()
+	if err := cache.Save(); err != nil {
+		return err
+	}
+	cachedCookieMu.Lock()
+	cachedCookie = cookie
+	cachedCookieMu.Unlock()
+	return nil
 }
 
 // performAuth handles the actual authentication process with a specific client
@@ -197,8 +224,8 @@ func (c *keeneticCommon) performAuth(client *resty.Client) error {
 			Password: sha256HashStr,
 		})
 
-		// set cookie globally
-		client.Header.Set("Cookie", cookieToSet)
+		// Set the cookie on this request only; the shared client cookie is
+		// refreshed via OnBeforeRequest in GetApiClient to avoid races.
 		secondRequest.Header.Set("Cookie", cookieToSet)
 
 		response, err = secondRequest.Post("/auth")
@@ -403,17 +430,25 @@ func (c *keeneticCommon) authRetryMiddleware(client *resty.Client, resp *resty.R
 			return nil
 		}
 
-		// Clear the current cookie and perform direct authentication
-		client.Header.Del("Cookie")
+		restyClientMu.Lock()
+		authErr := c.performAuth(client)
+		restyClientMu.Unlock()
+		if authErr != nil {
+			return authErr
+		}
 
-		if err := c.performAuth(client); err != nil {
+		// Read the fresh cookie from the cache so the retry carries it.
+		cookie, err := c.getAuthCookie()
+		if err != nil {
 			return err
 		}
 
 		// Retry the original request with new authentication, marking it as already retried.
 		retryReq := resp.Request.SetContext(context.WithValue(resp.Request.Context(), authRetriedKey{}, true))
 		retryReq.Header.Del("Cookie")
-		retryReq.Header.Set("Cookie", client.Header.Get("Cookie"))
+		if cookie != "" {
+			retryReq.Header.Set("Cookie", cookie)
+		}
 
 		retryResp, err := retryReq.Execute(resp.Request.Method, resp.Request.URL)
 		if err != nil {
@@ -433,23 +468,28 @@ func (c *keeneticCommon) GetApiClient() (*resty.Client, error) {
 		restyClient.SetDisableWarn(true)
 		restyClient.SetCookieJar(nil)
 		restyClient.SetTimeout(defaultTimeout)
+		restyClient.SetBaseURL(config.Cfg.Keenetic.URL)
+		// Inject the auth cookie per-request so concurrent callers never race on
+		// the shared client.Header map.
+		restyClient.OnBeforeRequest(func(_ *resty.Client, req *resty.Request) error {
+			if req.Header.Get("Cookie") != "" {
+				return nil
+			}
+			cookie, err := c.getAuthCookie()
+			if err != nil {
+				return err
+			}
+			if cookie != "" {
+				req.Header.Set("Cookie", cookie)
+			}
+			return nil
+		})
 		restyClient.OnAfterResponse(c.authRetryMiddleware)
 		restyClient.RetryCount = 3
+		if config.Cfg.Keenetic.TLSSkipVerify {
+			restyClient.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}) //nolint:gosec
+		}
 	})
-	// do it each time to have clean client
-	restyClient.SetBaseURL(config.Cfg.Keenetic.URL)
-	if config.Cfg.Keenetic.TLSSkipVerify {
-		restyClient.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: true}) //nolint:gosec
-	}
-	if restyClient.Header.Get("Cookie") == "" {
-		cookie, err := c.getAuthCookie()
-		if err != nil {
-			return nil, err
-		}
-		if cookie != "" {
-			restyClient.Header.Set("Cookie", cookie)
-		}
-	}
 	return restyClient, nil
 }
 

--- a/pkg/gokeenrestapi/common_test.go
+++ b/pkg/gokeenrestapi/common_test.go
@@ -74,9 +74,12 @@ var _ = Describe("GetApiClient", func() {
 		restyClient = nil
 		restyClientOnce = sync.Once{}
 		cleanedOldCache = false
+		cachedCookieMu.Lock()
+		cachedCookie = ""
+		cachedCookieMu.Unlock()
 	})
 
-	It("should return error instead of panicking when auth cache directory is unreadable", func() {
+	It("should surface auth cache error on request when DataDir is unreadable", func() {
 		// Set up a DataDir that exists but has no read permission so getAuthCookie fails
 		tmpDir, err := os.MkdirTemp("", "gokeenapi-test-noperm-*")
 		Expect(err).NotTo(HaveOccurred())
@@ -93,10 +96,40 @@ var _ = Describe("GetApiClient", func() {
 		restyClient = nil
 		restyClientOnce = sync.Once{}
 		cleanedOldCache = false
+		cachedCookieMu.Lock()
+		cachedCookie = ""
+		cachedCookieMu.Unlock()
 
+		// GetApiClient itself no longer fails; the error surfaces on the first request
+		// because cookie injection runs in OnBeforeRequest.
 		client, getErr := Common.GetApiClient()
-		Expect(getErr).To(HaveOccurred())
-		Expect(client).To(BeNil())
+		Expect(getErr).NotTo(HaveOccurred())
+		Expect(client).NotTo(BeNil())
+
+		_, reqErr := Common.ExecuteGetSubPath("/rci/show/version")
+		Expect(reqErr).To(HaveOccurred())
+	})
+
+	It("should be safe for concurrent use", func() {
+		server := SetupMockRouterForTest()
+		DeferCleanup(server.Close)
+
+		const goroutines = 20
+		errs := make(chan error, goroutines)
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+		for range goroutines {
+			go func() {
+				defer wg.Done()
+				_, err := Common.Version()
+				errs <- err
+			}()
+		}
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			Expect(err).NotTo(HaveOccurred())
+		}
 	})
 })
 

--- a/pkg/gokeenrestapi/ensure_save_config_test.go
+++ b/pkg/gokeenrestapi/ensure_save_config_test.go
@@ -87,6 +87,9 @@ var _ = Describe("SaveConfig", func() {
 		CleanupTestConfig()
 		restyClient = nil
 		restyClientOnce = sync.Once{}
+		cachedCookieMu.Lock()
+		cachedCookie = ""
+		cachedCookieMu.Unlock()
 	})
 
 	It("executes the save config command against the router", func() {

--- a/pkg/gokeenrestapi/test_helpers.go
+++ b/pkg/gokeenrestapi/test_helpers.go
@@ -30,6 +30,9 @@ func SetupTestConfig(serverURL string) {
 	// Reset client and its Once guard so the next call re-initializes with the new config.
 	restyClient = nil
 	restyClientOnce = sync.Once{}
+	cachedCookieMu.Lock()
+	cachedCookie = ""
+	cachedCookieMu.Unlock()
 }
 
 // CleanupTestConfig removes the temporary test cache directory


### PR DESCRIPTION
## What
Fix concurrent access races on the shared `restyClient` singleton in `pkg/gokeenrestapi/common.go`.

## Why
Multiple goroutines calling API methods concurrently (e.g. parallel scheduler strategy) could race on:
1. `client.Header` map — concurrent reads/writes without synchronisation
2. `SetBaseURL` called on every `GetApiClient()` invocation after `sync.Once`
3. `getKeeneticCacheFile` — concurrent first-time creation of the cache file

This caused corrupted auth state, requests sent to wrong router, and potential panics.

## Changes
- `restyClientMu` — serialises concurrent re-authentication in `authRetryMiddleware`
- `SetBaseURL` moved inside `sync.Once` — set exactly once, not on every call
- Cookie injection moved from `client.Header` to `OnBeforeRequest` middleware — each request carries its own header copy, shared `client.Header` is never mutated after init
- `cachedCookieMu` + in-memory `cachedCookie` — serialises `getAuthCookie`/`writeAuthCookie` and avoids concurrent cache-file creation on the first call
- Test helpers reset `cachedCookie` alongside existing `restyClient` resets
- Existing `GetApiClient` test updated (error now surfaces on first request, not from `GetApiClient` itself)
- New concurrency test: 20 goroutines calling `Version()` concurrently; passes with `--race`

## How to test
```
RACE=1 go run github.com/onsi/ginkgo/v2/ginkgo --race --procs=4 ./...
```
All 5 suites, 261 specs — all pass with race detector enabled.