### PR TITLE
Maintenance: docs(readme): add config reference section

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 </div>
 
-[🚀 Quick Start](#-quick-start) • [📖 Documentation](#-commands) • [🎨 GUI Version](https://github.com/Noksa/gokeenapiui) • [🤝 Contributing](#-contributing)
+[🚀 Quick Start](#-quick-start) • [📖 Documentation](#-commands) • [📋 Config Reference](#-config-reference) • [🎨 GUI Version](https://github.com/Noksa/gokeenapiui) • [🤝 Contributing](#-contributing)
 
 </div>
 
@@ -101,7 +101,7 @@ Download the latest release for your platform:
 
 ## ⚙️ Configuration
 
-`gokeenapi` is configured using a `yaml` file. You can find an example [here](https://github.com/Noksa/gokeenapi/blob/main/config_example.yaml).
+`gokeenapi` is configured using a `yaml` file. You can find an example [here](https://github.com/Noksa/gokeenapi/blob/main/config_example.yaml). For a complete description of every field, see the [Config Reference](#-config-reference) section below.
 
 To use your configuration file, pass the `--config <path>` flag with your command.
 
@@ -178,6 +178,143 @@ All configuration options can be set via environment variables:
 `GOKEENAPI_KEENETIC_LOGIN` and `GOKEENAPI_KEENETIC_PASSWORD` are particularly useful for keeping sensitive credentials out of config files. `GOKEENAPI_INSIDE_DOCKER` is set automatically in the official Docker image.
 
 > **Security recommendation**: Store credentials using environment variables instead of writing them directly into the config file. Config files stored with world-readable permissions (e.g. `0644`) will trigger a runtime warning. Restrict permissions with `chmod 600 config.yaml` and use `GOKEENAPI_KEENETIC_LOGIN` / `GOKEENAPI_KEENETIC_PASSWORD` to pass credentials. Add `config.yaml` and `config_*.yaml` to your `.gitignore` to prevent accidental commits (the project's default `.gitignore` already includes these patterns).
+
+---
+
+## 📋 Config Reference
+
+Complete reference for all fields in the `config.yaml` file. See [config_example.yaml](config_example.yaml) for a fully annotated example.
+
+### `keenetic` — Router connection
+
+Required by every command.
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `url` | string | ✅ | — | Router URL. Accepts IP address or KeenDNS hostname. Supports `http://` and `https://`. Example: `http://192.168.1.1` |
+| `login` | string | ✅ | — | Router admin username. Overridden by `GOKEENAPI_KEENETIC_LOGIN` env var. |
+| `password` | string | ✅ | — | Router admin password. Overridden by `GOKEENAPI_KEENETIC_PASSWORD` env var. |
+| `tls_skip_verify` | bool | ❌ | `false` | Disable TLS certificate verification. Enable when the router uses a self-signed certificate. |
+
+### `dataDir` — Data directory
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `dataDir` | string | ❌ | system default | Custom directory for application data files. Automatically set to `/etc/gokeenapi` when `GOKEENAPI_INSIDE_DOCKER` env var is present. |
+
+### `routes` — Static routes
+
+Used by: `add-routes`, `delete-routes`.
+
+A list of per-interface routing configurations.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `interfaceId` | string | ✅ | Target interface ID (e.g. `Wireguard0`). Run `show-interfaces` to list available IDs. |
+| `bat-file` | list of strings | ❌ | Paths to local `.bat` files with `route add` commands. A `.yaml`/`.yml` path is expanded to the `bat-file` list it contains. Relative paths are resolved from the config file's directory. |
+| `bat-url` | list of strings | ❌ | Remote URLs serving `.bat` files. A `.yaml`/`.yml` path is expanded to the `bat-url` list it contains. |
+
+At least one of `bat-file` or `bat-url` should be provided per entry.
+
+### `dns.records` — Static DNS records
+
+Used by: `add-dns-records`, `delete-dns-records`.
+
+A list of static DNS host entries to create in the router's local resolver. Each entry maps one domain name to one or more IPv4 addresses.
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `domain` | string | ✅ | Domain name to resolve (e.g. `myserver.local`). |
+| `ip` | list of strings | ✅ | One or more IPv4 addresses the domain should resolve to. |
+
+Example:
+
+```yaml
+dns:
+  records:
+    - domain: myserver.local
+      ip:
+        - 192.168.1.100
+        - 192.168.1.101
+    - domain: db.local
+      ip:
+        - 10.0.0.5
+```
+
+### `dns.routes.groups` — DNS-routing groups
+
+Used by: `add-dns-routing`, `delete-dns-routing`.
+
+A list of domain groups for policy-based routing. Each group creates an object-group and a dns-proxy route on the router. Requires Keenetic firmware ≥ 5.0.1.
+
+Each entry is either a **group object** or a **path to a `.yaml` file** that contains a `groups:` list (for sharing common groups across multiple router configs).
+
+**Group object fields:**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `name` | string | ✅ | Unique name for the object-group on the router. |
+| `interfaceId` | string | ✅ | Target interface for routing matched domain traffic (e.g. `Wireguard0`). Run `show-interfaces` to list available IDs. |
+| `domain-file` | list of strings | ❌ | Paths to local `.txt` files with one domain per line (lines starting with `#` are comments). A `.yaml`/`.yml` path is expanded to the `domain-file` list it contains. |
+| `domain-url` | list of strings | ❌ | Remote URLs serving domain lists (one domain per line). A `.yaml`/`.yml` path is expanded to the `domain-url` list it contains. |
+
+At least one of `domain-file` or `domain-url` is required per group.
+
+Example:
+
+```yaml
+dns:
+  routes:
+    groups:
+      - name: streaming
+        domain-file:
+          - domains/netflix.txt
+          - domains/youtube.txt
+        domain-url:
+          - https://example.com/spotify-domains.txt
+        interfaceId: Wireguard0
+
+      - name: work-vpn
+        domain-file:
+          - domains/internal.txt
+        interfaceId: GigabitEthernet0/Vlan4
+
+      # Import shared groups from a file
+      - common/shared_groups.yaml
+```
+
+### `add-awg` / `update-awg` — WireGuard commands
+
+These commands do not read any command-specific section from the config file. They require only the `keenetic` connection block. The WireGuard configuration is supplied via the `--conf-file` CLI flag, which points to a standard WireGuard `.conf` file:
+
+```ini
+[Interface]
+PrivateKey = <private-key>
+Address = 10.0.0.2/32
+
+[Peer]
+PublicKey = <public-key>
+Endpoint = vpn.example.com:51820
+AllowedIPs = 0.0.0.0/0
+```
+
+| CLI flag | Required | Description |
+|---|---|---|
+| `--conf-file` | ✅ | Path to a WireGuard `.conf` file. |
+| `--name` | ❌ (`add-awg` only) | Name for the new interface. Auto-generated if omitted. |
+| `--interface-id` | ✅ (`update-awg` only) | ID of the existing interface to update. |
+
+### `logs` — Logging
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `debug` | bool | ❌ | `false` | Enable debug-level logging. Also controllable with the `--debug` global flag. |
+
+### `cache` — Caching
+
+| Field | Type | Required | Default | Description |
+|---|---|---|---|---|
+| `urlTtl` | duration | ❌ | `1m` | How long to cache content downloaded from `bat-url` and `domain-url`. Accepts Go duration strings: `30s`, `5m`, `1h`. |
 
 ---
 


### PR DESCRIPTION
## What
Add a **Config Reference** section to README.md documenting all supported config fields and their types.

## Why
The README referenced `config_example.yaml` but never provided a structured reference listing every supported field, its type, whether it is required, and what it does. Users had to read the example file and the Go source to understand the config schema.

## How to test
1. Open the updated README.md (or the rendered GitHub view).
2. Confirm the **📋 Config Reference** section is present and covers: `keenetic`, `dataDir`, `routes`, `dns.records`, `dns.routes.groups`, AWG CLI flags, `logs`, and `cache`.
3. Confirm the top navigation bar includes a link to the new section.
4. Confirm the Configuration section intro links down to the reference.