### PR TITLE
Maintenance: docs(readme): add show-interfaces hint for --interface-id commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ Deletes static routes for a specific interface.
 ./gokeenapi delete-routes --config my_config.yaml --force
 ```
 
+> **Tip:** To find interface IDs, run `show-interfaces`.
+
 #### `add-dns-records`
 
 *Aliases: `adddnsrecords`, `adr`*
@@ -434,6 +436,8 @@ Updates an existing WireGuard connection from a `.conf` file.
 ```shell
 ./gokeenapi update-awg --config my_config.yaml --conf-file <path-to-conf> --interface-id <interface-id>
 ```
+
+> **Tip:** To find interface IDs, run `show-interfaces`.
 
 #### `delete-known-hosts`
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -309,6 +309,8 @@ tasks:
 ./gokeenapi delete-routes --config my_config.yaml --force
 ```
 
+> **Совет:** Чтобы найти ID интерфейсов, выполните команду `show-interfaces`.
+
 #### `add-dns-records`
 
 *Псевдонимы: `adddnsrecords`, `adr`*
@@ -434,6 +436,8 @@ dns:
 ```shell
 ./gokeenapi update-awg --config my_config.yaml --conf-file <путь-к-conf> --interface-id <interface-id>
 ```
+
+> **Совет:** Чтобы найти ID интерфейсов, выполните команду `show-interfaces`.
 
 #### `delete-known-hosts`
 


### PR DESCRIPTION
**What:** Add a tip note after each `--interface-id` usage in `delete-routes` and `update-awg` sections pointing users to `show-interfaces` to discover interface IDs.

**Why:** Users who don't know their interface ID have no indication of how to find it. The note eliminates this friction by directing them to the correct command.

**How to test:** Review README.md and README_RU.md — both `delete-routes` and `update-awg` sections should now have a Tip note after the code block containing `--interface-id`.