### PR TITLE
Maintenance: docs(readme): merge bat-file/bat-url sections into one

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,16 +105,18 @@ Download the latest release for your platform:
 
 To use your configuration file, pass the `--config <path>` flag with your command.
 
-### Reusable Bat-File Lists
+### Reusable Bat-File and Bat-URL Lists
 
-When managing multiple routers with the same routing configuration, you can create a YAML file containing a list of bat-file paths and reference it across multiple configs:
+When managing multiple routers with the same routing configuration, you can create a shared YAML file containing `bat-file` paths, `bat-url` paths, or both, and reference it across multiple configs.
 
-**batfiles/common-routes.yaml:**
+**batfiles/common.yaml:**
 ```yaml
 bat-file:
   - /path/to/discord.bat
   - /path/to/youtube.bat
-  - /path/to/instagram.bat
+bat-url:
+  - https://example.com/instagram.bat
+  - https://example.com/extra.bat
 ```
 
 **Router config:**
@@ -122,47 +124,14 @@ bat-file:
 routes:
   - interfaceId: Wireguard0
     bat-file:
-      - batfiles/common-routes.yaml  # Automatically expanded
-      - /path/to/router-specific.bat # Can mix with regular files
-```
-
-The tool automatically detects `.yaml`/`.yml` files in the `bat-file` array and expands them to their contained bat-file paths. Relative paths in YAML list files are resolved relative to the YAML file's directory.
-
-### Reusable Bat-URL Lists
-
-Similar to bat-file lists, you can create reusable YAML files containing bat-url paths:
-
-**batfiles/common-urls.yaml:**
-```yaml
-bat-url:
-  - https://example.com/discord.bat
-  - https://example.com/youtube.bat
-  - https://example.com/instagram.bat
-```
-
-**Router config:**
-```yaml
-routes:
-  - interfaceId: Wireguard0
+      - batfiles/common.yaml         # Expanded: only bat-file entries are used
+      - /path/to/router-specific.bat # Can mix with regular paths
     bat-url:
-      - batfiles/common-urls.yaml    # Automatically expanded
-      - https://example.com/extra.bat # Can mix with regular URLs
+      - batfiles/common.yaml         # Expanded: only bat-url entries are used
+      - https://example.com/other.bat
 ```
 
-The tool automatically detects `.yaml`/`.yml` files in the `bat-url` array and expands them to their contained bat-url paths. Relative paths in YAML list files are resolved relative to the YAML file's directory.
-
-**Note:** You can combine both `bat-file` and `bat-url` in the same YAML file. When a YAML file is referenced in `bat-file`, only its `bat-file` list is expanded. When referenced in `bat-url`, only its `bat-url` list is expanded:
-
-```yaml
-bat-file:
-  - /path/to/file1.bat
-  - /path/to/file2.bat
-bat-url:
-  - https://example.com/url1.bat
-  - https://example.com/url2.bat
-```
-
-This allows you to maintain both local files and remote URLs in a single reusable YAML file, referencing it appropriately in your config.
+The tool automatically detects `.yaml`/`.yml` files in the `bat-file` and `bat-url` arrays and expands them to their respective list entries. When a YAML file is referenced in `bat-file`, only its `bat-file` list is used; when referenced in `bat-url`, only its `bat-url` list is used. Relative paths in YAML list files are resolved relative to the YAML file's directory.
 
 ### Environment Variables
 

--- a/README_RU.md
+++ b/README_RU.md
@@ -105,16 +105,18 @@ docker run --rm -ti -v "$(pwd)/config_example.yaml":/gokeenapi/config.yaml \
 
 Чтобы использовать ваш конфигурационный файл, передайте флаг `--config <путь>` с вашей командой.
 
-### Переиспользуемые списки Bat-файлов
+### Переиспользуемые списки Bat-файлов и Bat-URL
 
-При управлении несколькими роутерами с одинаковой конфигурацией маршрутизации, вы можете создать YAML файл со списком путей к bat-файлам и ссылаться на него в разных конфигах:
+При управлении несколькими роутерами с одинаковой конфигурацией маршрутизации, вы можете создать общий YAML файл с путями к `bat-file`, путями к `bat-url` или и теми и другими, и ссылаться на него в разных конфигах.
 
-**batfiles/common-routes.yaml:**
+**batfiles/common.yaml:**
 ```yaml
 bat-file:
   - /path/to/discord.bat
   - /path/to/youtube.bat
-  - /path/to/instagram.bat
+bat-url:
+  - https://example.com/instagram.bat
+  - https://example.com/extra.bat
 ```
 
 **Конфиг роутера:**
@@ -122,47 +124,14 @@ bat-file:
 routes:
   - interfaceId: Wireguard0
     bat-file:
-      - batfiles/common-routes.yaml  # Автоматически раскрывается
-      - /path/to/router-specific.bat # Можно смешивать с обычными файлами
-```
-
-Утилита автоматически определяет `.yaml`/`.yml` файлы в массиве `bat-file` и раскрывает их в содержащиеся в них пути к bat-файлам. Относительные пути в YAML-файлах списков разрешаются относительно директории YAML-файла.
-
-### Переиспользуемые списки Bat-URL
-
-Аналогично спискам bat-файлов, вы можете создавать переиспользуемые YAML файлы со списком bat-url путей:
-
-**batfiles/common-urls.yaml:**
-```yaml
-bat-url:
-  - https://example.com/discord.bat
-  - https://example.com/youtube.bat
-  - https://example.com/instagram.bat
-```
-
-**Конфиг роутера:**
-```yaml
-routes:
-  - interfaceId: Wireguard0
+      - batfiles/common.yaml         # Раскрывается: используются только bat-file записи
+      - /path/to/router-specific.bat # Можно смешивать с обычными путями
     bat-url:
-      - batfiles/common-urls.yaml    # Автоматически раскрывается
-      - https://example.com/extra.bat # Можно смешивать с обычными URL
+      - batfiles/common.yaml         # Раскрывается: используются только bat-url записи
+      - https://example.com/other.bat
 ```
 
-Утилита автоматически определяет `.yaml`/`.yml` файлы в массиве `bat-url` и раскрывает их в содержащиеся в них пути к bat-url. Относительные пути в YAML-файлах списков разрешаются относительно директории YAML-файла.
-
-**Примечание:** Вы можете объединить `bat-file` и `bat-url` в одном YAML файле. Когда YAML файл указан в `bat-file`, раскрывается только его список `bat-file`. Когда указан в `bat-url`, раскрывается только его список `bat-url`:
-
-```yaml
-bat-file:
-  - /path/to/file1.bat
-  - /path/to/file2.bat
-bat-url:
-  - https://example.com/url1.bat
-  - https://example.com/url2.bat
-```
-
-Это позволяет хранить локальные файлы и удалённые URL в одном переиспользуемом YAML файле, ссылаясь на него соответствующим образом в конфигурации.
+Утилита автоматически определяет `.yaml`/`.yml` файлы в массивах `bat-file` и `bat-url` и раскрывает их в соответствующие записи списка. Когда YAML файл указан в `bat-file`, используется только его список `bat-file`; когда указан в `bat-url`, используется только его список `bat-url`. Относительные пути в YAML-файлах списков разрешаются относительно директории YAML-файла.
 
 ### Переменные окружения
 


### PR DESCRIPTION
**What**: Merge the three separate bat-file/bat-url expansion sections ("Reusable Bat-File Lists", "Reusable Bat-URL Lists", and the combined-file note) into a single unified "Reusable Bat-File and Bat-URL Lists" section.

**Why**: The same concept was explained three times with redundant prose and examples (~51 lines → ~20 lines). One section with a single combined example is clearer and easier to maintain.

**How to test**: Review that the merged section still covers: (1) bat-file-only YAML, (2) bat-url-only YAML, (3) combined YAML, and (4) the selective-expansion behaviour (bat-file refs only expand bat-file entries, and vice versa).