### PR TITLE
feat(delete-all-routes): add command to delete all static routes via single RCI POST request

### DIFF
--- a/cmd/constants.go
+++ b/cmd/constants.go
@@ -12,6 +12,7 @@ const (
 	CmdAddDnsRouting    = "add-dns-routing"
 	CmdDeleteDnsRouting = "delete-dns-routing"
 	CmdDeleteKnownHosts = "delete-known-hosts"
+	CmdDeleteAllRoutes  = "delete-all-routes"
 	CmdExec             = "exec"
 	CmdScheduler        = "scheduler"
 	CmdVersion          = "version"
@@ -40,6 +41,7 @@ var (
 	AliasesDeleteDnsRecords = []string{"deletednsrecords", "ddr"}
 	AliasesAddDnsRouting    = []string{"adddnsrouting", "adnsr", "adddnsroutes", "add-dns-routes"}
 	AliasesDeleteDnsRouting = []string{"deletednsrouting", "ddnsr", "deletednsroutes", "delete-dns-routes"}
+	AliasesDeleteAllRoutes  = []string{"deleteallroutes", "dar"}
 	AliasesDeleteKnownHosts = []string{"deleteknownhosts", "dkh"}
 	AliasesExec             = []string{"e"}
 	AliasesScheduler        = []string{"schedule", "sched"}

--- a/cmd/delete_all_routes.go
+++ b/cmd/delete_all_routes.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/fatih/color"
+	"github.com/noksa/gokeenapi/internal/gokeenlog"
+	"github.com/noksa/gokeenapi/pkg/gokeenrestapi"
+	"github.com/spf13/cobra"
+)
+
+func newDeleteAllRoutesCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     CmdDeleteAllRoutes,
+		Aliases: AliasesDeleteAllRoutes,
+		Short:   "Remove all static routes from the router",
+		Long: `Delete all static routes from your Keenetic (Netcraze) router in a single request.
+
+This command sends a single REST API call that removes every user-defined static
+route on the router at once. No route listing or per-route deletion is performed.
+
+Examples:
+  # Delete all routes
+  gokeenapi delete-all-routes --config config.yaml
+
+  # Delete without confirmation prompt
+  gokeenapi delete-all-routes --config config.yaml --force
+
+Safety: This command deletes ALL static routes. Use with caution.`,
+	}
+
+	var force bool
+	cmd.Flags().BoolVar(&force, "force", false,
+		`Skip confirmation prompt and delete routes immediately.
+Use with caution as this bypasses the safety confirmation.`)
+
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		if !force {
+			confirmed, err := confirmAction(fmt.Sprintf("\n%v This will delete %v static routes. Do you want to continue?", color.RedString("WARNING:"), color.CyanString("ALL")))
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				gokeenlog.Info("Deletion cancelled")
+				return nil
+			}
+		}
+
+		return gokeenrestapi.Ip.DeleteAllRoutes()
+	}
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,6 +84,7 @@ Can also be set via GOKEENAPI_CONFIG environment variable.`)
 	rootCmd.AddCommand(
 		newAddRoutesCmd(),
 		newDeleteRoutesCmd(),
+		newDeleteAllRoutesCmd(),
 		newShowInterfacesCmd(),
 		newUpdateAwgCmd(),
 		newAddAwgCmd(),

--- a/pkg/gokeenrestapi/ip.go
+++ b/pkg/gokeenrestapi/ip.go
@@ -398,3 +398,15 @@ func checkInterfaceContainsRoute(routeIp, mask, interfaceId string, existingRout
 	}
 	return false, nil
 }
+
+// DeleteAllRoutes removes all static routes from the router via a single RCI POST request.
+func (*keeneticIp) DeleteAllRoutes() error {
+	body := []any{
+		map[string]any{"ip": map[string]any{"route": []any{map[string]any{"no": true}}}},
+		map[string]any{"system": map[string]any{"configuration": map[string]any{"save": map[string]any{}}}},
+	}
+	return gokeenspinner.WrapWithSpinner("Deleting all static routes", func() error {
+		_, err := Common.ExecutePostSubPath("/rci/", body)
+		return err
+	})
+}


### PR DESCRIPTION
```
Jul 04 16:52:46 nixos podman[1780158]: ⌛   Authorizing in Keenetic ...
Jul 04 16:52:46 nixos eloquent_lederberg[1780183]: ⌛   Authorizing in Keenetic ...
Jul 04 16:52:47 nixos eloquent_lederberg[1780183]: ✅   Authorizing in Keenetic completed after 257ms
Jul 04 16:52:47 nixos eloquent_lederberg[1780183]:     ▪ Router: Challenger (KN-3910)
Jul 04 16:52:47 nixos podman[1780158]: ✅   Authorizing in Keenetic completed after 257ms
Jul 04 16:52:47 nixos podman[1780158]:     ▪ Router: Challenger (KN-3910)
Jul 04 16:52:47 nixos podman[1780158]:     ▪ OS version: 5.1 Beta 4
Jul 04 16:52:47 nixos podman[1780158]: ➖➖➖➖➖
Jul 04 16:52:47 nixos podman[1780158]: ⌛   Deleting all static routes ...
Jul 04 16:52:47 nixos eloquent_lederberg[1780183]:     ▪ OS version: 5.1 Beta 4
Jul 04 16:52:47 nixos eloquent_lederberg[1780183]: ➖➖➖➖➖
Jul 04 16:52:47 nixos eloquent_lederberg[1780183]: ⌛   Deleting all static routes ...
Jul 04 16:52:54 nixos eloquent_lederberg[1780183]: ✅   Deleting all static routes completed after 7.337s
Jul 04 16:52:54 nixos eloquent_lederberg[1780183]: ➖➖➖➖➖
Jul 04 16:52:54 nixos podman[1780158]: ✅   Deleting all static routes completed after 7.337s
```